### PR TITLE
feat: base launch announcement

### DIFF
--- a/barn/announcements-1.md
+++ b/barn/announcements-1.md
@@ -1,0 +1,1 @@
+The world's most-loved DEX is now (finally) live on the world's fastest-growing L2. [Start trading with CoW Swap on Base today](https://barn.cow.fi/#/8453/swap/WETH).

--- a/barn/announcements-100.md
+++ b/barn/announcements-100.md
@@ -1,0 +1,1 @@
+The world's most-loved DEX is now (finally) live on the world's fastest-growing L2. [Start trading with CoW Swap on Base today](https://barn.cow.fi/#/8453/swap/WETH).

--- a/barn/announcements-11155111.md
+++ b/barn/announcements-11155111.md
@@ -1,0 +1,1 @@
+The world's most-loved DEX is now (finally) live on the world's fastest-growing L2. [Start trading with CoW Swap on Base today](https://swap.cow.fi/#/8453/swap/WETH).

--- a/barn/announcements-42161.md
+++ b/barn/announcements-42161.md
@@ -1,0 +1,1 @@
+The world's most-loved DEX is now (finally) live on the world's fastest-growing L2. [Start trading with CoW Swap on Base today](https://barn.cow.fi/#/8453/swap/WETH).

--- a/production/announcements-1.md
+++ b/production/announcements-1.md
@@ -1,0 +1,1 @@
+The world's most-loved DEX is now (finally) live on the world's fastest-growing L2. [Start trading with CoW Swap on Base today](https://swap.cow.fi/#/8453/swap/WETH).

--- a/production/announcements-100.md
+++ b/production/announcements-100.md
@@ -1,0 +1,1 @@
+The world's most-loved DEX is now (finally) live on the world's fastest-growing L2. [Start trading with CoW Swap on Base today](https://swap.cow.fi/#/8453/swap/WETH).

--- a/production/announcements-11155111.md
+++ b/production/announcements-11155111.md
@@ -1,0 +1,1 @@
+The world's most-loved DEX is now (finally) live on the world's fastest-growing L2. [Start trading with CoW Swap on Base today](https://swap.cow.fi/#/8453/swap/WETH).

--- a/production/announcements-42161.md
+++ b/production/announcements-42161.md
@@ -1,0 +1,1 @@
+The world's most-loved DEX is now (finally) live on the world's fastest-growing L2. [Start trading with CoW Swap on Base today](https://swap.cow.fi/#/8453/swap/WETH).


### PR DESCRIPTION
# Summary

![image](https://github.com/user-attachments/assets/29dfc46f-9c98-4d41-866b-9c5a38c7f6f4)

Banner to be displayed on all chains, except on Base itself.

On Prod like envs, it points to swap.cow.fi.
On Barn, it points to barn.cow.fi